### PR TITLE
Added possibility to configure which payment methods are available

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -1,56 +1,59 @@
 name: Push Nuget Packages to NuGet Package Registry
 
 on:
-  push:
-    branches:
-      - main
-  workflow_dispatch:
+    push:
+        branches:
+            - main
+    workflow_dispatch:
 
 env:
-  BUILD_CONFIGURATION: "Release"
-  DOTNET_VERSION: "5.0.x"
-  GITHUB_PACKAGE_REGISTRY_URL: https://api.nuget.org/v3/index.json
+    BUILD_CONFIGURATION: "Release"
+    DOTNET_VERSION: "5.0.x"
+    GITHUB_PACKAGE_REGISTRY_URL: https://api.nuget.org/v3/index.json
 
 jobs:
-  gpr-build-and-deploy:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      
-      - name: Generate build number
-        id: build_number
-        uses: paulhatch/semantic-version@v4.0.2
-        with:
-          tag_prefix: "v"
+    gpr-build-and-deploy:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+              with:
+                  fetch-depth: 0
 
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
-          source-url: ${{ env.GITHUB_PACKAGE_REGISTRY_URL }}
-        env:
-          NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+            - name: Generate build number
+              id: build_number
+              uses: paulhatch/semantic-version@v4.0.2
+              with:
+                  tag_prefix: "v"
 
-      - name: dotnet build and publish
-        run: |
-          dotnet restore Api/BccPay.Core.sln
-          dotnet build Api/BccPay.Core.Domain/BccPay.Core.Domain.csproj -c ${{ env.BUILD_CONFIGURATION }} -p:PackageVersion=${{ steps.build_number.outputs.major }}.${{ steps.build_number.outputs.minor }}.${{ steps.build_number.outputs.increment }}
-          dotnet build Api/BccPay.Core.Infrastructure/BccPay.Core.Infrastructure.csproj -c ${{ env.BUILD_CONFIGURATION }} -p:PackageVersion=${{ steps.build_number.outputs.major }}.${{ steps.build_number.outputs.minor }}.${{ steps.build_number.outputs.increment }}
-          dotnet build Api/BccPay.Core.Cqrs/BccPay.Core.Cqrs.csproj -c ${{ env.BUILD_CONFIGURATION }} -p:PackageVersion=${{ steps.build_number.outputs.major }}.${{ steps.build_number.outputs.minor }}.${{ steps.build_number.outputs.increment }}
-          dotnet build Api/BccPay.Core.Enums/BccPay.Core.Enums.csproj -c ${{ env.BUILD_CONFIGURATION }} -p:PackageVersion=${{ steps.build_number.outputs.major }}.${{ steps.build_number.outputs.minor }}.${{ steps.build_number.outputs.increment }}
-          dotnet build Api/BccPay.Core.Shared/BccPay.Core.Shared.csproj -c ${{ env.BUILD_CONFIGURATION }} -p:PackageVersion=${{ steps.build_number.outputs.major }}.${{ steps.build_number.outputs.minor }}.${{ steps.build_number.outputs.increment }}
-          dotnet pack Api/BccPay.Core.Domain/BccPay.Core.Domain.csproj -c ${{ env.BUILD_CONFIGURATION }} -p:PackageVersion=${{ steps.build_number.outputs.major }}.${{ steps.build_number.outputs.minor }}.${{ steps.build_number.outputs.increment }}
-          dotnet pack Api/BccPay.Core.Infrastructure/BccPay.Core.Infrastructure.csproj -c ${{ env.BUILD_CONFIGURATION }} -p:PackageVersion=${{ steps.build_number.outputs.major }}.${{ steps.build_number.outputs.minor }}.${{ steps.build_number.outputs.increment }}
-          dotnet pack Api/BccPay.Core.Cqrs/BccPay.Core.Cqrs.csproj -c ${{ env.BUILD_CONFIGURATION }} -p:PackageVersion=${{ steps.build_number.outputs.major }}.${{ steps.build_number.outputs.minor }}.${{ steps.build_number.outputs.increment }}
-          dotnet pack Api/BccPay.Core.Enums/BccPay.Core.Enums.csproj -c ${{ env.BUILD_CONFIGURATION }} -p:PackageVersion=${{ steps.build_number.outputs.major }}.${{ steps.build_number.outputs.minor }}.${{ steps.build_number.outputs.increment }}
-          dotnet pack Api/BccPay.Core.Shared/BccPay.Core.Shared.csproj -c ${{ env.BUILD_CONFIGURATION }} -p:PackageVersion=${{ steps.build_number.outputs.major }}.${{ steps.build_number.outputs.minor }}.${{ steps.build_number.outputs.increment }}
+            - name: Setup .NET
+              uses: actions/setup-dotnet@v1
+              with:
+                  dotnet-version: ${{ env.DOTNET_VERSION }}
+                  source-url: ${{ env.GITHUB_PACKAGE_REGISTRY_URL }}
+              env:
+                  NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
-      - name: nuget publish
-        run: |
-          dotnet nuget push Api/BccPay.Core.Infrastructure/bin/Release/*.nupkg -k ${{ secrets.NUGET_API_KEY }} --skip-duplicate
-          dotnet nuget push Api/BccPay.Core.Domain/bin/Release/*.nupkg -k ${{ secrets.NUGET_API_KEY }} --skip-duplicate
-          dotnet nuget push Api/BccPay.Core.Cqrs/bin/Release/*.nupkg -k ${{ secrets.NUGET_API_KEY }} --skip-duplicate
-          dotnet nuget push Api/BccPay.Core.Enums/bin/Release/*.nupkg -k ${{ secrets.NUGET_API_KEY }} --skip-duplicate
-          dotnet nuget push Api/BccPay.Core.Shared/bin/Release/*.nupkg -k ${{ secrets.NUGET_API_KEY }} --skip-duplicate
+            - name: dotnet build and publish
+              run: |
+                  dotnet restore Api/BccPay.Core.sln
+                  dotnet build Api/BccPay.Core.Domain/BccPay.Core.Domain.csproj -c ${{ env.BUILD_CONFIGURATION }} -p:PackageVersion=${{ steps.build_number.outputs.major }}.${{ steps.build_number.outputs.minor }}.${{ steps.build_number.outputs.increment }}
+                  dotnet build Api/BccPay.Core.Infrastructure/BccPay.Core.Infrastructure.csproj -c ${{ env.BUILD_CONFIGURATION }} -p:PackageVersion=${{ steps.build_number.outputs.major }}.${{ steps.build_number.outputs.minor }}.${{ steps.build_number.outputs.increment }}
+                  dotnet build Api/BccPay.Core.Cqrs/BccPay.Core.Cqrs.csproj -c ${{ env.BUILD_CONFIGURATION }} -p:PackageVersion=${{ steps.build_number.outputs.major }}.${{ steps.build_number.outputs.minor }}.${{ steps.build_number.outputs.increment }}
+                  dotnet build Api/BccPay.Core.Enums/BccPay.Core.Enums.csproj -c ${{ env.BUILD_CONFIGURATION }} -p:PackageVersion=${{ steps.build_number.outputs.major }}.${{ steps.build_number.outputs.minor }}.${{ steps.build_number.outputs.increment }}
+                  dotnet build Api/BccPay.Core.Shared/BccPay.Core.Shared.csproj -c ${{ env.BUILD_CONFIGURATION }} -p:PackageVersion=${{ steps.build_number.outputs.major }}.${{ steps.build_number.outputs.minor }}.${{ steps.build_number.outputs.increment }}
+                  dotnet build Api/BccPay.Core.DataAccess/BccPay.Core.DataAccess.csproj -c ${{ env.BUILD_CONFIGURATION }} -p:PackageVersion=${{ steps.build_number.outputs.major }}.${{ steps.build_number.outputs.minor }}.${{ steps.build_number.outputs.increment }}
+                  dotnet pack Api/BccPay.Core.Domain/BccPay.Core.Domain.csproj -c ${{ env.BUILD_CONFIGURATION }} -p:PackageVersion=${{ steps.build_number.outputs.major }}.${{ steps.build_number.outputs.minor }}.${{ steps.build_number.outputs.increment }}
+                  dotnet pack Api/BccPay.Core.Infrastructure/BccPay.Core.Infrastructure.csproj -c ${{ env.BUILD_CONFIGURATION }} -p:PackageVersion=${{ steps.build_number.outputs.major }}.${{ steps.build_number.outputs.minor }}.${{ steps.build_number.outputs.increment }}
+                  dotnet pack Api/BccPay.Core.Cqrs/BccPay.Core.Cqrs.csproj -c ${{ env.BUILD_CONFIGURATION }} -p:PackageVersion=${{ steps.build_number.outputs.major }}.${{ steps.build_number.outputs.minor }}.${{ steps.build_number.outputs.increment }}
+                  dotnet pack Api/BccPay.Core.Enums/BccPay.Core.Enums.csproj -c ${{ env.BUILD_CONFIGURATION }} -p:PackageVersion=${{ steps.build_number.outputs.major }}.${{ steps.build_number.outputs.minor }}.${{ steps.build_number.outputs.increment }}
+                  dotnet pack Api/BccPay.Core.Shared/BccPay.Core.Shared.csproj -c ${{ env.BUILD_CONFIGURATION }} -p:PackageVersion=${{ steps.build_number.outputs.major }}.${{ steps.build_number.outputs.minor }}.${{ steps.build_number.outputs.increment }}
+                  dotnet pack Api/BccPay.Core.DataAccess/BccPay.Core.DataAccess.csproj -c ${{ env.BUILD_CONFIGURATION }} -p:PackageVersion=${{ steps.build_number.outputs.major }}.${{ steps.build_number.outputs.minor }}.${{ steps.build_number.outputs.increment }}
+
+            - name: nuget publish
+              run: |
+                  dotnet nuget push Api/BccPay.Core.Infrastructure/bin/Release/*.nupkg -k ${{ secrets.NUGET_API_KEY }} --skip-duplicate
+                  dotnet nuget push Api/BccPay.Core.Domain/bin/Release/*.nupkg -k ${{ secrets.NUGET_API_KEY }} --skip-duplicate
+                  dotnet nuget push Api/BccPay.Core.Cqrs/bin/Release/*.nupkg -k ${{ secrets.NUGET_API_KEY }} --skip-duplicate
+                  dotnet nuget push Api/BccPay.Core.Enums/bin/Release/*.nupkg -k ${{ secrets.NUGET_API_KEY }} --skip-duplicate
+                  dotnet nuget push Api/BccPay.Core.Shared/bin/Release/*.nupkg -k ${{ secrets.NUGET_API_KEY }} --skip-duplicate
+                  dotnet nuget push Api/BccPay.Core.DataAccess/bin/Release/*.nupkg -k ${{ secrets.NUGET_API_KEY }} --skip-duplicate

--- a/Api/BccPay.Core.Cqrs/BccPay.Core.Cqrs.csproj
+++ b/Api/BccPay.Core.Cqrs/BccPay.Core.Cqrs.csproj
@@ -9,6 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\BccPay.Core.DataAccess\BccPay.Core.DataAccess.csproj" />
     <ProjectReference Include="..\BccPay.Core.Domain\BccPay.Core.Domain.csproj" />
     <ProjectReference Include="..\BccPay.Core.Infrastructure\BccPay.Core.Infrastructure.csproj" />
     <ProjectReference Include="..\BccPay.Core.Shared\BccPay.Core.Shared.csproj" />

--- a/Api/BccPay.Core.Cqrs/Queries/GetCountryPaymentConfigurationsQuery.cs
+++ b/Api/BccPay.Core.Cqrs/Queries/GetCountryPaymentConfigurationsQuery.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using BccPay.Core.DataAccess.Indexes;
+using BccPay.Core.Domain.Entities;
+using BccPay.Core.Enums;
+using BccPay.Core.Infrastructure.Exceptions;
+using MediatR;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Session;
+
+namespace BccPay.Core.Cqrs.Queries
+{
+    public record GetCountryPaymentConfigurationsQuery(string countryCode) : IRequest<List<PaymentConfigurationResult>>;
+
+    public class PaymentConfigurationResult
+    {
+        public string Id { get; set; }
+
+        public PaymentMethod PaymentMethod { get; set; }
+
+        public PaymentProvider Provider { get; set; }
+
+        public Currency Currency { get; set; }
+
+        public string CountryCode { get; set; }
+    }
+
+    public class GetCountryPaymentConfigurationsQueryHandler : IRequestHandler<GetCountryPaymentConfigurationsQuery, List<PaymentConfigurationResult>>
+    {
+        private readonly IAsyncDocumentSession _documentSession;
+
+        public GetCountryPaymentConfigurationsQueryHandler(IAsyncDocumentSession documentSession)
+        {
+            _documentSession = documentSession
+                ?? throw new ArgumentNullException(nameof(documentSession));
+        }
+
+        public async Task<List<PaymentConfigurationResult>> Handle(GetCountryPaymentConfigurationsQuery request, CancellationToken cancellationToken)
+        {
+            var configurations = await _documentSession.Query<CountryPaymentConfigurationsIndex.Result, CountryPaymentConfigurationsIndex>()
+                                    .Where(x => x.CountryCode == request.countryCode || x.CountryCode == Country.DefaultCountryCode)
+                                    .Select(x => new PaymentConfigurationResult
+                                    {
+                                        Id = x.Id,
+                                        Currency = x.Currency,
+                                        PaymentMethod = x.PaymentMethod,
+                                        Provider = x.PaymentProvider,
+                                        CountryCode = x.CountryCode
+                                    })
+                                    .ToListAsync(cancellationToken);
+
+            if (configurations.Count(c => c.CountryCode == Country.DefaultCountryCode) != 1)
+            {
+                throw new InvalidConfigurationException("There must be one payment configuration with the 'default' country code");
+            }
+
+            // remove default configuration if we have it explicitly specified for the country
+            if (configurations.Count > 1)
+            {
+                configurations = configurations.Where(x => x.CountryCode != Country.DefaultCountryCode).ToList();
+            }
+
+            return configurations;
+        }
+    }
+}

--- a/Api/BccPay.Core.Cqrs/Queries/GetPaymentsQuery.cs
+++ b/Api/BccPay.Core.Cqrs/Queries/GetPaymentsQuery.cs
@@ -58,7 +58,7 @@ namespace BccPay.Core.Cqrs.Queries
                                     PaymentStatus = payment.PaymentStatus,
                                     Created = payment.Created,
                                     Updated = payment.Updated,
-                                    AmountOfAttempts = payment.Attempts.Count
+                                    AmountOfAttempts = payment.Attempts != null ? payment.Attempts.Count : 0
                                 }).ToListAsync(token: cancellationToken);
 
             return new PaymentsResult(result);

--- a/Api/BccPay.Core.DataAccess/BccPay.Core.DataAccess.csproj
+++ b/Api/BccPay.Core.DataAccess/BccPay.Core.DataAccess.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
+    <RepositoryUrl>https://github.com/bcc-code/bcc-pay</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Api/BccPay.Core.DataAccess/BccPay.Core.DataAccess.csproj
+++ b/Api/BccPay.Core.DataAccess/BccPay.Core.DataAccess.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
+    <PackageReference Include="RavenDB.Client" Version="5.2.1" />
+    <PackageReference Include="RavenDB.DependencyInjection" Version="4.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BccPay.Core.Domain\BccPay.Core.Domain.csproj" />
+    <ProjectReference Include="..\BccPay.Core.Enums\BccPay.Core.Enums.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Api/BccPay.Core.DataAccess/Indexes/CountryPaymentConfigurationsIndex.cs
+++ b/Api/BccPay.Core.DataAccess/Indexes/CountryPaymentConfigurationsIndex.cs
@@ -1,0 +1,39 @@
+﻿using System.Linq;
+using BccPay.Core.Domain;
+using BccPay.Core.Domain.Entities;
+using BccPay.Core.Enums;
+using Raven.Client.Documents.Indexes;
+
+namespace BccPay.Core.DataAccess.Indexes
+{
+    public class CountryPaymentConfigurationsIndex : AbstractMultiMapIndexCreationTask<CountryPaymentConfigurationsIndex.Result>
+    {
+        public CountryPaymentConfigurationsIndex()
+        {
+            AddMap<Country>(countries => from country in countries
+                                         from configId in country.PaymentConfigurations
+                                         let config = LoadDocument<PaymentConfiguration>("payment-configurations/" + configId)
+                                         select new Result
+                                         {
+                                             Id = configId,
+                                             CountryCode = country.CountryCode,
+                                             Currency = config.Settings.Currency,
+                                             PaymentMethod = config.Settings.PaymentMethod,
+                                             PaymentProvider = config.Provider
+                                         });
+        }
+
+        public class Result
+        {
+            public string Id { get; set; }
+
+            public string CountryCode { get; set; }
+
+            public Currency Currency { get; set; }
+
+            public PaymentMethod PaymentMethod { get; set; }
+
+            public PaymentProvider PaymentProvider { get; set; }
+        }
+    }
+}

--- a/Api/BccPay.Core.DataAccess/ServiceInstaller.cs
+++ b/Api/BccPay.Core.DataAccess/ServiceInstaller.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Reflection;
+using System.Security.Cryptography.X509Certificates;
+using Microsoft.AspNetCore.Builder;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.DependencyInjection;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static class ServiceInstaller
+    {
+        public static IServiceCollection AddRavenDatabaseDocumentStore(this IServiceCollection services)
+        {
+            services.AddRavenDbDocStore();
+            services.AddRavenDbDocStore(options =>
+            {
+                if (!string.IsNullOrWhiteSpace(options.Settings.CertFilePath))
+                    options.Certificate = new X509Certificate2(Convert.FromBase64String(options.Settings.CertFilePath), options.Settings.CertPassword);
+            });
+            services.AddRavenDbAsyncSession();
+            services.AddRavenDbSession();
+
+            return services;
+        }
+
+        public static IApplicationBuilder WarmUpIndexesInRavenDatabase(
+            this IApplicationBuilder app, params Assembly[] assembliesWithIndexes)
+        {
+            var docStore = app.ApplicationServices.GetRequiredService<IDocumentStore>();
+            IndexCreation.CreateIndexes(Assembly.GetExecutingAssembly(), docStore);
+            foreach (Assembly assembly in assembliesWithIndexes)
+            {
+                IndexCreation.CreateIndexes(assembly, docStore);
+            }
+
+            return app;
+        }
+    }
+}

--- a/Api/BccPay.Core.Domain/Entities/Country.cs
+++ b/Api/BccPay.Core.Domain/Entities/Country.cs
@@ -2,9 +2,11 @@
 {
     public class Country
     {
-        public static string GetCountryId(string countryCode) => $"countries/{countryCode}";
+        public static string DefaultCountryCode = "default";
 
-        public string Id => GetCountryId(CountryCode);
+        public static string GetDocumentId(string countryCode) => $"countries/{countryCode}";
+
+        public string Id => GetDocumentId(CountryCode);
 
         public string CountryCode { get; set; }
 

--- a/Api/BccPay.Core.Domain/Entities/NetsStatusDetails.cs
+++ b/Api/BccPay.Core.Domain/Entities/NetsStatusDetails.cs
@@ -1,6 +1,4 @@
-﻿using Newtonsoft.Json;
-
-namespace BccPay.Core.Domain.Entities
+﻿namespace BccPay.Core.Domain.Entities
 {
     public class NetsStatusDetails : IStatusDetails
     {

--- a/Api/BccPay.Core.Domain/Entities/PaymentConfiguration.cs
+++ b/Api/BccPay.Core.Domain/Entities/PaymentConfiguration.cs
@@ -4,15 +4,13 @@ namespace BccPay.Core.Domain
 {
     public class PaymentConfiguration
     {
-        public static string GetPaymentConfigurationId(string countryCode) => $"payment-configurations/{countryCode}";
+        public static string GetDocumentId(string code) => $"payment-configurations/{code}";
 
-        public string Id => GetPaymentConfigurationId(PaymentConfigurationCode);
-
-        public string CountryCode { get; set; }
+        public string Id => GetDocumentId(PaymentConfigurationCode);
 
         public string PaymentConfigurationCode { get; init; }
 
-        public PaymentProvider Provider { get; init; }
+        public PaymentProvider Provider { get; set; }
 
         public PaymentSettings Settings { get; set; }
     }

--- a/Api/BccPay.Core.Enums/PaymentMethod.cs
+++ b/Api/BccPay.Core.Enums/PaymentMethod.cs
@@ -1,7 +1,10 @@
-﻿namespace BccPay.Core.Enums
+﻿using System.ComponentModel;
+
+namespace BccPay.Core.Enums
 {
     public enum PaymentMethod
     {
+        [Description("Credit Card")]
         CreditCard
     }
 }

--- a/Api/BccPay.Core.Infrastructure/BccPay.Core.Infrastructure.csproj
+++ b/Api/BccPay.Core.Infrastructure/BccPay.Core.Infrastructure.csproj
@@ -12,10 +12,11 @@
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="10.3.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Net.Http.Headers" Version="2.2.8" />
-    <PackageReference Include="RavenDB.DependencyInjection" Version="4.0.2" />
+    <PackageReference Include="RavenDB.Client" Version="5.2.1" />
     <PackageReference Include="Refit" Version="6.0.38" />
     <PackageReference Include="Refit.HttpClientFactory" Version="6.0.38" />
   </ItemGroup>

--- a/Api/BccPay.Core.Infrastructure/BccPaymentsSettings.cs
+++ b/Api/BccPay.Core.Infrastructure/BccPaymentsSettings.cs
@@ -1,0 +1,9 @@
+﻿using BccPay.Core.Infrastructure.PaymentProviders;
+
+namespace BccPay.Core.Infrastructure
+{
+    public class BccPaymentsSettings
+    {
+        public NetsProviderOptions Nets { get; } = new NetsProviderOptions();
+    }
+}

--- a/Api/BccPay.Core.Infrastructure/Configuration/BccPaymentsConfiguration.cs
+++ b/Api/BccPay.Core.Infrastructure/Configuration/BccPaymentsConfiguration.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using BccPay.Core.Domain;
+using BccPay.Core.Enums;
+
+namespace BccPay.Core.Infrastructure.Configuration
+{
+    public class BccPaymentsConfiguration
+    {
+        public List<BccPaymentConfiguration> PaymentConfigurations { get; set; } = new List<BccPaymentConfiguration>();
+
+        public List<CountryBccPaymentConfigurations> CountryPaymentConfigurations { get; set; } = new List<CountryBccPaymentConfigurations>();
+    }
+
+    public class BccPaymentConfiguration
+    {
+        public string Id { get; init; }
+
+        public PaymentProvider Provider { get; set; }
+
+        public PaymentSettings Settings { get; set; }
+    }
+
+    public class CountryBccPaymentConfigurations
+    {
+        public string CountryCode { get; init; }
+
+        public string[] PaymentConfigurationIds { get; set; }
+    }
+}

--- a/Api/BccPay.Core.Infrastructure/Configuration/PaymentConfigurationsService.cs
+++ b/Api/BccPay.Core.Infrastructure/Configuration/PaymentConfigurationsService.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using BccPay.Core.Domain;
+using BccPay.Core.Domain.Entities;
+using Microsoft.Extensions.Options;
+using Raven.Client.Documents.Session;
+
+namespace BccPay.Core.Infrastructure.Configuration
+{
+    public interface IPaymentConfigurationsService
+    {
+        void InitPaymentsConfiguration();
+    }
+
+    internal class PaymentConfigurationsService : IPaymentConfigurationsService
+    {
+        private readonly IDocumentSession _documentSession;
+        private readonly IOptions<BccPaymentsConfiguration> _bccPaymentsConfiguration;
+
+        public PaymentConfigurationsService(IDocumentSession documentSession, IOptions<BccPaymentsConfiguration> bccPaymentsConfiguration)
+        {
+            _documentSession = documentSession
+                ?? throw new ArgumentNullException(nameof(documentSession));
+
+            _bccPaymentsConfiguration = bccPaymentsConfiguration;
+        }
+
+        public void InitPaymentsConfiguration()
+        {
+            this.UpdatePaymentConfigurations(_bccPaymentsConfiguration.Value.PaymentConfigurations);
+
+            this.UpdateCountries(_bccPaymentsConfiguration.Value.CountryPaymentConfigurations);
+
+            _documentSession.SaveChanges();
+        }
+
+        private void UpdatePaymentConfigurations(List<BccPaymentConfiguration> paymentConfigs)
+        {
+            var oldPaymentConfigs = _documentSession.Query<PaymentConfiguration>().ToList();
+
+            // add/update payment configurations
+            foreach (var config in paymentConfigs)
+            {
+                var oldConfig = oldPaymentConfigs.FirstOrDefault(x => x.PaymentConfigurationCode == config.Id);
+                if (oldConfig != null)
+                {
+                    oldConfig.Provider = config.Provider;
+                    oldConfig.Settings = config.Settings;
+                }
+                else
+                {
+                    _documentSession.Store(new PaymentConfiguration
+                    {
+                        PaymentConfigurationCode = config.Id,
+                        Provider = config.Provider,
+                        Settings = config.Settings
+                    });
+                }
+            }
+
+            // remove old configurations
+            oldPaymentConfigs
+                .Where(x => !paymentConfigs.Any(c => c.Id == x.PaymentConfigurationCode))
+                .ToList()
+                .ForEach(_documentSession.Delete);
+        }
+
+        private void UpdateCountries(List<CountryBccPaymentConfigurations> countryPaymentConfigurations)
+        {
+            var existingCountries = _documentSession.Query<Country>().ToList();
+
+            // do not remove country if it isn't specified, just remove payment configurations
+            existingCountries.ForEach(c => c.PaymentConfigurations = Array.Empty<string>());
+
+            foreach (var config in countryPaymentConfigurations)
+            {
+                var existingConfig = existingCountries.FirstOrDefault(x => x.CountryCode == config.CountryCode);
+                if (existingConfig != null)
+                {
+                    existingConfig.PaymentConfigurations = config.PaymentConfigurationIds;
+                }
+                else
+                {
+                    _documentSession.Store(new Country
+                    {
+                        CountryCode = config.CountryCode,
+                        PaymentConfigurations = config.PaymentConfigurationIds
+                    });
+                }
+            }
+        }
+    }
+}

--- a/Api/BccPay.Core.Infrastructure/Exceptions/BccPayCoreException.cs
+++ b/Api/BccPay.Core.Infrastructure/Exceptions/BccPayCoreException.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Net;
+
+namespace BccPay.Core.Infrastructure.Exceptions
+{
+    [Serializable]
+    public abstract class BccPayCoreException : Exception
+    {
+        public BccPayCoreException(string message, HttpStatusCode statusCode = HttpStatusCode.BadRequest)
+            : base(message)
+        {
+            StatusCode = statusCode;
+        }
+
+        public HttpStatusCode StatusCode { get; private set; }
+    }
+}

--- a/Api/BccPay.Core.Infrastructure/Exceptions/InvalidConfigurationException.cs
+++ b/Api/BccPay.Core.Infrastructure/Exceptions/InvalidConfigurationException.cs
@@ -1,0 +1,11 @@
+﻿using System.Net;
+
+namespace BccPay.Core.Infrastructure.Exceptions
+{
+    public class InvalidConfigurationException : BccPayCoreException
+    {
+        public InvalidConfigurationException(string message, HttpStatusCode statusCode = HttpStatusCode.BadRequest) : base(message, statusCode)
+        {
+        }
+    }
+}

--- a/Api/BccPay.Core.Infrastructure/PaymentProviders/PaymentProviderOptions.cs
+++ b/Api/BccPay.Core.Infrastructure/PaymentProviders/PaymentProviderOptions.cs
@@ -8,9 +8,4 @@
         public string TermsUrl { get; set; }
         public string NotificationUrl { get; set; }
     }
-
-    public class PaymentProviderOptions
-    {
-        public NetsProviderOptions Nets { get; } = new NetsProviderOptions();
-    }
 }

--- a/Api/BccPay.Core.Infrastructure/ServiceInstaller.cs
+++ b/Api/BccPay.Core.Infrastructure/ServiceInstaller.cs
@@ -1,66 +1,43 @@
-﻿using BccPay.Core.Infrastructure.PaymentProviders;
+﻿using System;
+using BccPay.Core.Infrastructure;
+using BccPay.Core.Infrastructure.Configuration;
+using BccPay.Core.Infrastructure.PaymentProviders;
 using BccPay.Core.Infrastructure.PaymentProviders.Implementations;
 using BccPay.Core.Infrastructure.PaymentProviders.RefitClients;
 using Microsoft.AspNetCore.Builder;
-using Raven.Client.Documents;
-using Raven.Client.Documents.Indexes;
-using Raven.DependencyInjection;
 using Refit;
-using System;
-using System.Reflection;
-using System.Security.Cryptography.X509Certificates;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
     public static class ServiceInstaller
     {
-        public static IServiceCollection ConfigureBccPayInfrastructure(
+        public static IServiceCollection ConfigureBccPayInfrastructureServices(
             this IServiceCollection services,
-            Action<PaymentProviderOptions> configuration)
+            Action<BccPaymentsSettings> configuration)
         {
-            var defaultOptions = new PaymentProviderOptions();
+            var defaultOptions = new BccPaymentsSettings();
             configuration(defaultOptions);
 
             services.AddScoped<IPaymentProvider, NetsPaymentProvider>(implementationFactory =>
             {
-                return new NetsPaymentProvider(implementationFactory.GetRequiredService<INetsClient>(),
-                    defaultOptions.Nets);
+                return new NetsPaymentProvider(implementationFactory.GetRequiredService<INetsClient>(), defaultOptions.Nets);
             });
 
             services.AddScoped<IPaymentProviderFactory, PaymentProviderFactory>();
-
+            services.AddScoped<IPaymentConfigurationsService, PaymentConfigurationsService>();
             services.AddRefitClient<INetsClient>()
                 .ConfigureHttpClient(client => client.BaseAddress = new Uri(defaultOptions.Nets.BaseAddress));
 
             return services;
         }
 
-        public static IServiceCollection AddRavenDatabaseDocumentStore(this IServiceCollection services)
+        public static void InitPaymentsConfiguration(this IApplicationBuilder app)
         {
+            using var serviceScope = app.ApplicationServices.CreateScope();
 
-            Raven.DependencyInjection.ServiceCollectionExtensions.AddRavenDbDocStore(services);
-            services.AddRavenDbDocStore(options =>
-            {
-                if (!string.IsNullOrWhiteSpace(options.Settings.CertFilePath))
-                    options.Certificate = new X509Certificate2(Convert.FromBase64String(options.Settings.CertFilePath), options.Settings.CertPassword);
-            });
-            services.AddRavenDbAsyncSession();
+            var paymentConfigurationsService = serviceScope.ServiceProvider.GetRequiredService<IPaymentConfigurationsService>();
 
-            return services;
-        }
-
-        public static IApplicationBuilder WarmUpIndexesInRavenDatabase(
-            this IApplicationBuilder app, Assembly[]
-            assembliesWithIndexes)
-        {
-            var docStore = app.ApplicationServices.GetRequiredService<IDocumentStore>();
-
-            foreach (Assembly assembly in assembliesWithIndexes)
-            {
-                IndexCreation.CreateIndexes(assembly, docStore);
-            }
-
-            return app;
+            paymentConfigurationsService.InitPaymentsConfiguration();
         }
     }
 }

--- a/Api/BccPay.Core.Sample/BccPay.Core.Sample.csproj
+++ b/Api/BccPay.Core.Sample/BccPay.Core.Sample.csproj
@@ -13,11 +13,13 @@
     <PackageReference Include="RavenDB.Client" Version="5.2.1" />
     <PackageReference Include="RavenDB.DependencyInjection" Version="4.0.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
+    <PackageReference Include="System.Text.Json" Version="5.0.2" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\BccPay.Core.Contracts\BccPay.Core.Contracts.csproj" />
     <ProjectReference Include="..\BccPay.Core.Cqrs\BccPay.Core.Cqrs.csproj" />
+    <ProjectReference Include="..\BccPay.Core.DataAccess\BccPay.Core.DataAccess.csproj" />
     <ProjectReference Include="..\BccPay.Core.Domain\BccPay.Core.Domain.csproj" />
     <ProjectReference Include="..\BccPay.Core.Infrastructure\BccPay.Core.Infrastructure.csproj" />
   </ItemGroup>

--- a/Api/BccPay.Core.Sample/Controllers/PaymentConfigurationsController.cs
+++ b/Api/BccPay.Core.Sample/Controllers/PaymentConfigurationsController.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using BccPay.Core.Cqrs.Queries;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BccPay.Core.Sample.Controllers
+{
+    [ApiController]
+    [Route("payment-configurations")]
+    public class PaymentConfigurationsController : BaseController
+    {
+        [HttpGet]
+        [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(List<PaymentConfigurationResult>))]
+        public async Task<IActionResult> GetPaymentConfigurations([FromQuery] string countryCode)
+        {
+            var query = new GetCountryPaymentConfigurationsQuery(countryCode);
+
+            var result = await Mediator.Send(query);
+
+            return Ok(result);
+        }
+    }
+}

--- a/Api/BccPay.Core.Sample/Controllers/PaymentController.cs
+++ b/Api/BccPay.Core.Sample/Controllers/PaymentController.cs
@@ -1,4 +1,6 @@
-﻿using BccPay.Core.Contracts.Requests;
+﻿using System;
+using System.Threading.Tasks;
+using BccPay.Core.Contracts.Requests;
 using BccPay.Core.Contracts.Responses;
 using BccPay.Core.Cqrs.Commands;
 using BccPay.Core.Cqrs.Queries;
@@ -7,8 +9,6 @@ using BccPay.Core.Infrastructure.PaymentModels.Webhooks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Net.Http.Headers;
-using System;
-using System.Threading.Tasks;
 
 namespace BccPay.Core.Sample.Controllers
 {

--- a/Api/BccPay.Core.Sample/Startup.cs
+++ b/Api/BccPay.Core.Sample/Startup.cs
@@ -1,5 +1,10 @@
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text.Json.Serialization;
 using BccPay.Core.Cqrs;
 using BccPay.Core.Cqrs.Commands;
+using BccPay.Core.Domain;
+using BccPay.Core.Infrastructure.Configuration;
 using BccPay.Core.Sample.Mappers;
 using BccPay.Core.Sample.Middleware;
 using BccPay.Core.Sample.Validation;
@@ -11,8 +16,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi.Models;
-using System.Collections.Generic;
-using System.Reflection;
 
 namespace BccPay.Core.Sample
 {
@@ -27,9 +30,12 @@ namespace BccPay.Core.Sample
 
         public void ConfigureServices(IServiceCollection services)
         {
+            var bccPaymentsConfiguration = Configuration.GetSection("BccPaymentsConfiguration");
+            services.Configure<BccPaymentsConfiguration>(bccPaymentsConfiguration);
+
             services.AddRavenDatabaseDocumentStore();
 
-            services.ConfigureBccPayInfrastructure(options =>
+            services.ConfigureBccPayInfrastructureServices(options =>
             {
                 options.Nets.BaseAddress = "https://test.api.dibspayment.eu";
                 options.Nets.CheckoutPageUrl = "https://localhost:4000/";
@@ -42,7 +48,11 @@ namespace BccPay.Core.Sample
 
 
             services.AddTransient(typeof(IPipelineBehavior<,>), typeof(RequestValidationBehavior<,>));
-            services.AddMvc().AddFluentValidation(fv => fv.RegisterValidatorsFromAssemblies(new List<Assembly> { typeof(CreatePaymentCommandValidator).Assembly }));
+            services.AddMvc()
+                .AddJsonOptions(op => {
+                    op.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+                })
+                .AddFluentValidation(fv => fv.RegisterValidatorsFromAssemblies(new List<Assembly> { typeof(CreatePaymentCommandValidator).Assembly }));
             services.AddAutoMapper(typeof(PaymentProfile).Assembly);
 
             services.AddControllers();
@@ -73,7 +83,9 @@ namespace BccPay.Core.Sample
                 endpoints.MapControllers();
             });
 
-            //app.WarmUpIndexesInRavenDatabase();
+            app.WarmUpIndexesInRavenDatabase();
+
+            app.InitPaymentsConfiguration();
         }
     }
 }

--- a/Api/BccPay.Core.Sample/appsettings.Development.json
+++ b/Api/BccPay.Core.Sample/appsettings.Development.json
@@ -8,9 +8,7 @@
   },
   "RavenSettings": {
     "Urls": [
-        "https://a.test.samvirk.ravendb.cloud/",
-        "https://b.test.samvirk.ravendb.cloud/",
-        "https://c.test.samvirk.ravendb.cloud/"
+        "https://a.free.bcc-pay-dev.ravendb.cloud/"
     ],
     "DatabaseName": "Bcc-Pay-Core-Dev"
   }

--- a/Api/BccPay.Core.Sample/appsettings.json
+++ b/Api/BccPay.Core.Sample/appsettings.json
@@ -1,10 +1,28 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft": "Warning",
+            "Microsoft.Hosting.Lifetime": "Information"
+        }
+    },
+    "AllowedHosts": "*",
+    "BccPaymentsConfiguration": {
+        "PaymentConfigurations": [
+            {
+                "Id": "nets-cc-eur",
+                "Provider": "Nets",
+                "Settings": {
+                    "Currency": "EUR",
+                    "PaymentMethod": "CreditCard"
+                }
+            }
+        ],
+        "CountryPaymentConfigurations": [
+            {
+                "CountryCode": "de",
+                "PaymentConfigurationIds": [ "nets-cc-eur" ]
+            }
+        ]
     }
-  },
-  "AllowedHosts": "*"
 }

--- a/Api/BccPay.Core.sln
+++ b/Api/BccPay.Core.sln
@@ -17,7 +17,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BccPay.Core.Contracts", "Bc
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "BccPay.Core.Public", "BccPay.Core.Public", "{088542F1-5AC6-418B-ACC8-A6D3060BC52F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BccPay.Core.Shared", "BccPay.Core.Shared\BccPay.Core.Shared.csproj", "{1718B835-A430-418A-975B-8D20F48B32F0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BccPay.Core.Shared", "BccPay.Core.Shared\BccPay.Core.Shared.csproj", "{1718B835-A430-418A-975B-8D20F48B32F0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BccPay.Core.DataAccess", "BccPay.Core.DataAccess\BccPay.Core.DataAccess.csproj", "{5362DE62-BEC0-4756-B782-A5599E30B6AD}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -53,6 +55,10 @@ Global
 		{1718B835-A430-418A-975B-8D20F48B32F0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1718B835-A430-418A-975B-8D20F48B32F0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1718B835-A430-418A-975B-8D20F48B32F0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5362DE62-BEC0-4756-B782-A5599E30B6AD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5362DE62-BEC0-4756-B782-A5599E30B6AD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5362DE62-BEC0-4756-B782-A5599E30B6AD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5362DE62-BEC0-4756-B782-A5599E30B6AD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Implementation of the issue 15 (As a devops engineer, I want to configure which payment methods should be available for each country)
- Added BccPaymentsConfiguration section to appsettings.json
- Settings are read in Startup and inserted to RavenDB (or updated if record exists)
- Added API `GET api/payment-configurations?countryCode=de` returning available configurations for the country