### PR TITLE
Make checkout Url dependent on the origin

### DIFF
--- a/Api/BccPay.Core.Infrastructure/PaymentProviders/Implementations/Nets/INetsPaymentRequestBuilder.cs
+++ b/Api/BccPay.Core.Infrastructure/PaymentProviders/Implementations/Nets/INetsPaymentRequestBuilder.cs
@@ -5,6 +5,6 @@ namespace BccPay.Core.Infrastructure.PaymentProviders.Implementations.Nets
 {
     public interface INetsPaymentRequestBuilder
     {
-        NetsPaymentRequest BuildNetsPaymentRequest(PaymentRequestDto paymentRequest, bool IsUserDataValid = true);
+        NetsPaymentRequest BuildNetsPaymentRequest(PaymentRequestDto paymentRequest, string originUrl, bool isUserDataValid = true);
     }
 }

--- a/Api/BccPay.Core.Infrastructure/PaymentProviders/Implementations/Nets/NetsCreditCardRequestBuilder.cs
+++ b/Api/BccPay.Core.Infrastructure/PaymentProviders/Implementations/Nets/NetsCreditCardRequestBuilder.cs
@@ -16,7 +16,7 @@ namespace BccPay.Core.Infrastructure.PaymentProviders.Implementations.Nets
             _options = options;
         }
 
-        public NetsPaymentRequest BuildNetsPaymentRequest(PaymentRequestDto paymentRequest, bool IsUserDataValid = true)
+        public NetsPaymentRequest BuildNetsPaymentRequest(PaymentRequestDto paymentRequest, string originUrl, bool IsUserDataValid = true)
         {
             int amountMonets = Convert.ToInt32(paymentRequest.Amount * 100);
             List<Webhook> webhooks = new();
@@ -65,7 +65,7 @@ namespace BccPay.Core.Infrastructure.PaymentProviders.Implementations.Nets
                         IntegrationType = PaymentProviderConstants.Nets.Order.IntegrationType,
                         Charge = true,
                         MerchantHandlesConsumerData = true,
-                        Url = _options.CheckoutPageUrl,
+                        Url = $"{originUrl}{_options.CheckoutPageUrl}",
                         TermsUrl = _options.TermsUrl,
                         Consumer = new ConsumerOnCreate
                         {
@@ -104,7 +104,7 @@ namespace BccPay.Core.Infrastructure.PaymentProviders.Implementations.Nets
                             IntegrationType = PaymentProviderConstants.Nets.Order.IntegrationType,
                             Charge = false,
                             MerchantHandlesConsumerData = false,
-                            Url = _options.CheckoutPageUrl,
+                            Url = $"{originUrl}{_options.CheckoutPageUrl}",
                             TermsUrl = _options.TermsUrl,
                         },
                     Order = order,

--- a/Api/BccPay.Core.Infrastructure/PaymentProviders/Implementations/Nets/NetsPaymentProvider.cs
+++ b/Api/BccPay.Core.Infrastructure/PaymentProviders/Implementations/Nets/NetsPaymentProvider.cs
@@ -8,6 +8,7 @@ using BccPay.Core.Enums;
 using BccPay.Core.Infrastructure.Dtos;
 using BccPay.Core.Infrastructure.PaymentProviders.Implementations.Nets;
 using BccPay.Core.Infrastructure.PaymentProviders.RefitClients;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Net.Http.Headers;
 using Refit;
 
@@ -17,15 +18,16 @@ namespace BccPay.Core.Infrastructure.PaymentProviders.Implementations
     {
         private readonly INetsClient _netsClient;
         private readonly NetsProviderOptions _options;
+        private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly IDictionary<string, string> _headers;
 
-        public NetsPaymentProvider(INetsClient netsClient, NetsProviderOptions options)
+        public NetsPaymentProvider(INetsClient netsClient, NetsProviderOptions options, IHttpContextAccessor httpContextAccessor)
         {
             _netsClient = netsClient
                 ?? throw new ArgumentNullException(nameof(netsClient));
 
             _options = options;
-
+            _httpContextAccessor = httpContextAccessor;
             _headers = new Dictionary<string, string>
             {
                 { HeaderNames.Authorization, _options.SecretKey },
@@ -38,9 +40,12 @@ namespace BccPay.Core.Infrastructure.PaymentProviders.Implementations
         public async Task<IStatusDetails> CreatePayment(PaymentRequestDto paymentRequest, PaymentSettings settings)
         {
             INetsPaymentRequestBuilder requestBuilder = this.CreateRequestBuilder(settings);
+            var referer = new Uri(_httpContextAccessor.HttpContext.Request.Headers["Referer"].ToString());
+            var host = $"{referer.Scheme}://{referer.Authority}";
+
             try
             {
-                var result = await _netsClient.CreatePaymentAsync(_headers, requestBuilder.BuildNetsPaymentRequest(paymentRequest));
+                var result = await _netsClient.CreatePaymentAsync(_headers, requestBuilder.BuildNetsPaymentRequest(paymentRequest, host));
 
                 return new NetsStatusDetails
                 {
@@ -52,7 +57,7 @@ namespace BccPay.Core.Infrastructure.PaymentProviders.Implementations
             {
                 try
                 {
-                    var result = await _netsClient.CreatePaymentAsync(_headers, requestBuilder.BuildNetsPaymentRequest(paymentRequest, false));
+                    var result = await _netsClient.CreatePaymentAsync(_headers, requestBuilder.BuildNetsPaymentRequest(paymentRequest, host, isUserDataValid: false));
                     return new NetsStatusDetails
                     {
                         IsSuccessful = true,

--- a/Api/BccPay.Core.Infrastructure/ServiceInstaller.cs
+++ b/Api/BccPay.Core.Infrastructure/ServiceInstaller.cs
@@ -1,14 +1,15 @@
-﻿using BccPay.Core.Infrastructure.PaymentProviders;
+﻿using System;
+using System.Reflection;
+using System.Security.Cryptography.X509Certificates;
+using BccPay.Core.Infrastructure.PaymentProviders;
 using BccPay.Core.Infrastructure.PaymentProviders.Implementations;
 using BccPay.Core.Infrastructure.PaymentProviders.RefitClients;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.DependencyInjection;
 using Refit;
-using System;
-using System.Reflection;
-using System.Security.Cryptography.X509Certificates;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -24,7 +25,8 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddScoped<IPaymentProvider, NetsPaymentProvider>(implementationFactory =>
             {
                 return new NetsPaymentProvider(implementationFactory.GetRequiredService<INetsClient>(),
-                    defaultOptions.Nets);
+                    defaultOptions.Nets,
+                    implementationFactory.GetRequiredService<IHttpContextAccessor>());
             });
 
             services.AddScoped<IPaymentProviderFactory, PaymentProviderFactory>();

--- a/Api/BccPay.Core.Sample/Startup.cs
+++ b/Api/BccPay.Core.Sample/Startup.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Reflection;
 using BccPay.Core.Cqrs;
 using BccPay.Core.Cqrs.Commands;
 using BccPay.Core.Sample.Mappers;
@@ -11,8 +13,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi.Models;
-using System.Collections.Generic;
-using System.Reflection;
 
 namespace BccPay.Core.Sample
 {
@@ -33,7 +33,7 @@ namespace BccPay.Core.Sample
             services.ConfigureBccPayInfrastructure(options =>
             {
                 options.Nets.BaseAddress = "https://test.api.dibspayment.eu";
-                options.Nets.CheckoutPageUrl = "http://localhost:8000";
+                options.Nets.CheckoutPageUrl = "/checkout";
                 options.Nets.TermsUrl = "http://localhost:8000";
                 options.Nets.SecretKey = Configuration["SecretKey"];
                 options.Nets.NotificationUrl = "https://localhost:5001/Payment/webhook";
@@ -53,7 +53,7 @@ namespace BccPay.Core.Sample
                             .AllowAnyHeader();
                     });
             });
-            
+
             services.AddTransient(typeof(IPipelineBehavior<,>), typeof(RequestValidationBehavior<,>));
             services.AddMvc().AddFluentValidation(fv => fv.RegisterValidatorsFromAssemblies(new List<Assembly> { typeof(CreatePaymentCommandValidator).Assembly }));
             services.AddAutoMapper(typeof(PaymentProfile).Assembly);

--- a/Api/BccPay.Core.Sample/appsettings.Development.json
+++ b/Api/BccPay.Core.Sample/appsettings.Development.json
@@ -12,9 +12,7 @@
     "CertFilePath": "",
     "CertPassword": "",
     "Urls": [
-        "https://a.test.samvirk.ravendb.cloud/",
-        "https://b.test.samvirk.ravendb.cloud/",
-        "https://c.test.samvirk.ravendb.cloud/"
+        "https://a.free.bcc-pay-dev.ravendb.cloud/"
     ],
     "DatabaseName": "Bcc-Pay-Core-Dev"
   },


### PR DESCRIPTION
In order to be able to use BccPay.Core Api from any host (allowed by CORS), Checkout URL is now built dynamically using:
```
var referer = new Uri(_httpContextAccessor.HttpContext.Request.Headers["Referer"].ToString());
var host = $"{referer.Scheme}://{referer.Authority}";
var checkoutUrl = $"{host}/checkout";
```